### PR TITLE
replace django.utils.simplejson with json

### DIFF
--- a/mailchimp/chimpy/chimpy.py
+++ b/mailchimp/chimpy/chimpy.py
@@ -4,7 +4,7 @@ import pprint
 from utils import transform_datetime
 from utils import flatten
 from warnings import warn
-from django.utils import simplejson
+import json as simplejson
 _debug = 1
 
 

--- a/mailchimp/models.py
+++ b/mailchimp/models.py
@@ -1,11 +1,11 @@
 from django.db import models
-from django.utils import simplejson
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes import generic
 from django.core.urlresolvers import reverse
 from django.shortcuts import get_object_or_404
 from django.utils.translation import ugettext_lazy as _
 from mailchimp.utils import get_connection
+import json as simplejson
 
 
 class QueueManager(models.Manager):

--- a/mailchimp/utils.py
+++ b/mailchimp/utils.py
@@ -4,7 +4,6 @@ from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.core.cache import cache
 from django.contrib.contenttypes.models import ContentType
-from django.utils import simplejson
 from django.contrib.auth import logout
 from django.contrib.messages import debug, info, success, warning, error, add_message
 from django.http import (
@@ -16,6 +15,7 @@ from django.http import (
 from mailchimp.settings import API_KEY, SECURE, REAL_CACHE, CACHE_TIMEOUT
 import re
 import warnings
+import json as simplejson
 
 class KeywordArguments(dict):
     def __getattr__(self, attr):

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,8 @@
 from setuptools import setup, find_packages
 
-version = __import__('mailchimp').__version__
-
 setup(
     name = 'django-mailchimp-v1.3',
-    version = version,
+    version = 1.3, # Otherwise buildout fails
     description = 'Mailchimp wrapper for Django, using Mailchimp API 1.3',
     author = 'Jonas Obrist et al.',
     url = 'http://github.com/piquadrat/django-mailchimp',


### PR DESCRIPTION
Recommend replacing django.utils.simpleson with import json as simplejson. It has been removed in django 1.7

See here https://docs.djangoproject.com/en/1.7/internals/deprecation/

Ignore the changes in setup.py, they were quickly added to get a project up and running.